### PR TITLE
Fixed share diagram button display

### DIFF
--- a/src/ontodia/workspace/workspace.ts
+++ b/src/ontodia/workspace/workspace.ts
@@ -51,7 +51,7 @@ export class Workspace extends Component<Props, {}> {
                 onPrint: () => this.diagram.print(),
                 onExportSVG: link => this.onExportSvg(link),
                 onExportPNG: link => this.onExportPng(link),
-                onShare: () => this.props.onShareDiagram(this),
+                onShare: this.props.onShareDiagram ? () => this.props.onShareDiagram(this) : undefined,
                 onSaveDiagram: () => this.props.onSaveDiagram(this),
                 onForceLayout: () => {
                     this.forceLayout();


### PR DESCRIPTION
We're passing a closure that will always be true. This could also be the case for other props being forwarded. Do we really need a closure every time here?