### PR TITLE
Fix multiple self-referencing links and not-yet-loaded link type errors

### DIFF
--- a/src/ontodia/diagram/model.ts
+++ b/src/ontodia/diagram/model.ts
@@ -479,7 +479,9 @@ export class DiagramModel extends Backbone.Model {
         }
 
         this.sourceOf(link).links.push(link);
-        this.targetOf(link).links.push(link);
+        if (link.sourceId !== link.targetId) {
+            this.targetOf(link).links.push(link);
+        }
     }
 
     getLink(linkModel: LinkModel): Link | undefined {
@@ -532,7 +534,9 @@ function placeholderTemplateFromIri(iri: string): ElementModel {
 function removeLinkFrom(links: Link[], model: LinkModel) {
     if (!links) { return; }
     const index = findLinkIndex(links, model);
-    links.splice(index, 1);
+    if (index >= 0) {
+        links.splice(index, 1);
+    }
 }
 
 function findLinkIndex(haystack: Link[], needle: LinkModel) {

--- a/src/ontodia/viewUtils/connectionsMenu.tsx
+++ b/src/ontodia/viewUtils/connectionsMenu.tsx
@@ -88,12 +88,9 @@ export class ConnectionsMenu {
 
                 const countMap: Dictionary<ConnectionCount> = {};
                 const links: FatLinkType[] = [];
-                for (const linkCount of linkTypes) {
-                    countMap[linkCount.id] = {
-                        inCount: linkCount.inCount,
-                        outCount: linkCount.outCount,
-                    };
-                    links.push(this.view.model.getLinkType(linkCount.id));
+                for (const {id: linkTypeId, inCount, outCount} of linkTypes) {
+                    countMap[linkTypeId] = {inCount, outCount};
+                    links.push(this.view.model.createLinkType(linkTypeId));
                 }
 
                 countMap[ALL_RELATED_ELEMENTS_LINK.id] = Object.keys(countMap)


### PR DESCRIPTION
Fix stack overflow when routing multiple self-referencing links, ConnectionsMenu error when link type isn't loaded yet.