### PR TITLE
Limit maximum number of connected elements in Connection Menu

### DIFF
--- a/src/ontodia/data/sparql/responseHandler.ts
+++ b/src/ontodia/data/sparql/responseHandler.ts
@@ -263,6 +263,16 @@ export function getLinksTypesOf(response: SparqlResponse<LinkCountBinding>): Lin
     return sparqlLinkTypes.map((sLink: LinkCountBinding) => getLinkCount(sLink));
 }
 
+export function getLinksTypeIds(response: SparqlResponse<LinkTypeBinding>): string[] {
+    const sparqlLinkTypes = response.results.bindings.filter(b => !isRdfBlank(b.link));
+    return sparqlLinkTypes.map((sLink: LinkTypeBinding) => sLink.link.value);
+}
+
+export function getLinkStatistic(response: SparqlResponse<LinkCountBinding>): LinkCount {
+    const sparqlLinkCount = response.results.bindings.filter(b => !isRdfBlank(b.link))[0];
+    return  getLinkCount(sparqlLinkCount);
+}
+
 export function getFilteredData(response: SparqlResponse<ElementBinding>): Dictionary<ElementModel> {
     const sInstances = response.results.bindings;
     const instancesMap: Dictionary<ElementModel> = {};

--- a/src/ontodia/data/sparql/responseHandler.ts
+++ b/src/ontodia/data/sparql/responseHandler.ts
@@ -268,7 +268,7 @@ export function getLinksTypeIds(response: SparqlResponse<LinkTypeBinding>): stri
     return sparqlLinkTypes.map((sLink: LinkTypeBinding) => sLink.link.value);
 }
 
-export function getLinkStatistic(response: SparqlResponse<LinkCountBinding>): LinkCount {
+export function getLinkStatistics(response: SparqlResponse<LinkCountBinding>): LinkCount {
     const sparqlLinkCount = response.results.bindings.filter(b => !isRdfBlank(b.link))[0];
     return  getLinkCount(sparqlLinkCount);
 }

--- a/src/ontodia/data/sparql/sparqlDataProvider.ts
+++ b/src/ontodia/data/sparql/sparqlDataProvider.ts
@@ -14,7 +14,7 @@ import {
     getEnrichedElementsInfo,
     getLinkTypesInfo,
     getLinksTypesOf,
-    getLinkStatistic,
+    getLinkStatistics,
 } from './responseHandler';
 import {
     ClassBinding, ElementBinding, LinkBinding, PropertyBinding, BlankBinding,
@@ -248,26 +248,17 @@ export class SparqlDataProvider implements DataProvider {
                 const requests: Promise<LinkCount>[] = [];
                 for (const id of linkTypeIds) {
                     const q = this.settings.defaultPrefix
-                    + resolveTemplate(this.settings.linkTypesOfStatsQuery, {
+                    + resolveTemplate(this.settings.linkTypesStatisticsQuery, {
                         linkId:  escapeIri(id),
                         elementIri,
                         linkConfigurations: this.formatLinkTypesOf(params.elementId)
                     });
                     requests.push(
-                        this.executeSparqlQuery<LinkCountBinding>(q).then(getLinkStatistic)
+                        this.executeSparqlQuery<LinkCountBinding>(q).then(getLinkStatistics)
                     );
                 }
                 return Promise.all(requests);
             });
-
-        // SparqlResponse<Binding> {
-        //     head: { vars: string[] };
-        //     results: { bindings: {
-        //         link: RdfIri | RdfBlank;
-        //         inCount: RdfLiteral;
-        //         outCount: RdfLiteral;
-        //     }[] };
-        // }
     };
 
     linkElements(params: {

--- a/src/ontodia/data/sparql/sparqlDataProvider.ts
+++ b/src/ontodia/data/sparql/sparqlDataProvider.ts
@@ -9,10 +9,12 @@ import {
     getLinkTypes,
     getElementsInfo,
     getLinksInfo,
-    getLinksTypesOf,
+    getLinksTypeIds,
     getFilteredData,
     getEnrichedElementsInfo,
     getLinkTypesInfo,
+    getLinksTypesOf,
+    getLinkStatistic,
 } from './responseHandler';
 import {
     ClassBinding, ElementBinding, LinkBinding, PropertyBinding, BlankBinding,
@@ -235,11 +237,37 @@ export class SparqlDataProvider implements DataProvider {
             return Promise.resolve(getLinksTypesOf(BlankNodes.linkTypesOf(params)));
         }
         const elementIri = escapeIri(params.elementId);
+        // Ask for linkTypes
         const query = this.settings.defaultPrefix
             + resolveTemplate(this.settings.linkTypesOfQuery,
                 {elementIri, linkConfigurations: this.formatLinkTypesOf(params.elementId)},
-                );
-        return this.executeSparqlQuery<LinkCountBinding>(query).then(getLinksTypesOf);
+            );
+        return this.executeSparqlQuery<LinkTypeBinding>(query)
+            .then(linkTypeBinding => {
+                const linkTypeIds = getLinksTypeIds(linkTypeBinding);
+                const requests: Promise<LinkCount>[] = [];
+                for (const id of linkTypeIds) {
+                    const q = this.settings.defaultPrefix
+                    + resolveTemplate(this.settings.linkTypesOfStatsQuery, {
+                        linkId:  escapeIri(id),
+                        elementIri,
+                        linkConfigurations: this.formatLinkTypesOf(params.elementId)
+                    });
+                    requests.push(
+                        this.executeSparqlQuery<LinkCountBinding>(q).then(getLinkStatistic)
+                    );
+                }
+                return Promise.all(requests);
+            });
+
+        // SparqlResponse<Binding> {
+        //     head: { vars: string[] };
+        //     results: { bindings: {
+        //         link: RdfIri | RdfBlank;
+        //         inCount: RdfLiteral;
+        //         outCount: RdfLiteral;
+        //     }[] };
+        // }
     };
 
     linkElements(params: {

--- a/src/ontodia/data/sparql/sparqlDataProviderSettings.ts
+++ b/src/ontodia/data/sparql/sparqlDataProviderSettings.ts
@@ -55,6 +55,11 @@ export interface SparqlDataProviderSettings {
     linkTypesOfQuery: string;
 
     /**
+     * link types of stats returns statistics of a link type for specified resource
+     */
+    linkTypesOfStatsQuery: string;
+
+    /**
      * when fetching all links from element, we could specify additional filter
      */
     filterRefElementLinkPattern: string;
@@ -141,6 +146,7 @@ export const RDFSettings: SparqlDataProviderSettings = {
     imageQueryPattern: ``,
 
     linkTypesOfQuery: ``,
+    linkTypesOfStatsQuery: ``,
     filterRefElementLinkPattern: '',
     filterTypePattern: ``,
     filterAdditionalRestriction: ``,
@@ -219,21 +225,39 @@ const WikidataSettingsOverride: Partial<SparqlDataProviderSettings> = {
                 BIND(CONCAT("https://commons.wikimedia.org/w/thumb.php?f=",
                     STRAFTER(STR(?fullImage), "Special:FilePath/"), "&w=200") AS ?image)`,
     linkTypesOfQuery: `
-        SELECT ?link (count(distinct ?outObject) as ?outCount) (count(distinct ?inObject) as ?inCount)
+        SELECT DISTINCT ?link
         WHERE {
-            { \${elementIri} ?link ?outObject .
-              # this is to prevent some junk appear on diagram,
-              # but can really slow down execution on complex objects
-              FILTER ISIRI(?outObject)
-              FILTER EXISTS { ?outObject ?someprop ?someobj }
-            }
-            UNION
-            { ?inObject ?link \${elementIri} .
-              FILTER ISIRI(?inObject)
-              FILTER EXISTS { ?inObject ?someprop ?someobj }
+            {
+                \${elementIri} ?link ?outObject
+                # this is to prevent some junk appear on diagram,
+                # but can really slow down execution on complex objects
+                #FILTER ISIRI(?outObject)
+                #FILTER EXISTS { ?outObject ?someprop ?someobj }
+            } UNION {
+                ?inObject ?link \${elementIri}
+                #FILTER ISIRI(?inObject)
+                #FILTER EXISTS { ?inObject ?someprop ?someobj }
             }
             FILTER regex(STR(?link), "direct")
-        } GROUP BY ?link
+        }
+    `,
+    linkTypesOfStatsQuery: `
+        SELECT ?link ?outCount ?inCount
+        WHERE {
+            { 
+                SELECT (\${linkId} as ?link) (count(?outObject) as ?outCount) WHERE {
+                    \${elementIri} \${linkId} ?outObject
+                    FILTER ISIRI(?outObject)
+                    FILTER EXISTS { ?outObject ?someprop ?someobj }
+                } LIMIT 101
+            } {
+                SELECT (\${linkId} as ?link) (count(?inObject) as ?inCount) WHERE {
+                    ?inObject \${linkId} \${elementIri}
+                    FILTER ISIRI(?inObject)
+                    FILTER EXISTS { ?inObject ?someprop ?someobj }
+                } LIMIT 101
+            } 
+        }
     `,
     filterRefElementLinkPattern: 'FILTER regex(STR(?link), "direct")',
     filterTypePattern: `?inst wdt:P31 ?instType. ?instType wdt:P279* \${elementTypeIri} . ${'\n'}`,
@@ -303,12 +327,26 @@ export const OWLRDFSSettingsOverride: Partial<SparqlDataProviderSettings> = {
     `,
     imageQueryPattern: `{ ?inst ?linkType ?image } UNION { [] ?linkType ?inst. BIND(?inst as ?image) }`,
     linkTypesOfQuery: `
-        SELECT ?link (count(distinct ?outObject) as ?outCount) (count(distinct ?inObject) as ?inCount) 
+        SELECT DISTINCT ?link
         WHERE {
-            { \${elementIri} ?link ?outObject}
+            { \${elementIri} ?link ?outObject }
             UNION 
-            { ?inObject ?link \${elementIri}}
-        } GROUP BY ?link
+            { ?inObject ?link \${elementIri} }
+        }
+    `,
+    linkTypesOfStatsQuery: `
+        SELECT ?link ?outCount ?inCount
+        WHERE {
+            { 
+                SELECT (\${linkId} as ?link) (count(?outObject) as ?outCount) WHERE {
+                    \${elementIri} \${linkId} ?outObject
+                } LIMIT 101
+            } {
+                SELECT (\${linkId} as ?link) (count(?inObject) as ?inCount) WHERE {
+                ?inObject \${linkId} \${elementIri}
+                } LIMIT 101
+            } 
+        }
     `,
     filterRefElementLinkPattern: '',
     filterTypePattern: `?inst rdf:type \${elementTypeIri} . ${'\n'}`,

--- a/src/ontodia/data/sparql/sparqlDataProviderSettings.ts
+++ b/src/ontodia/data/sparql/sparqlDataProviderSettings.ts
@@ -57,7 +57,7 @@ export interface SparqlDataProviderSettings {
     /**
      * link types of stats returns statistics of a link type for specified resource
      */
-    linkTypesOfStatsQuery: string;
+    linkTypesStatisticsQuery: string;
 
     /**
      * when fetching all links from element, we could specify additional filter
@@ -146,7 +146,7 @@ export const RDFSettings: SparqlDataProviderSettings = {
     imageQueryPattern: ``,
 
     linkTypesOfQuery: ``,
-    linkTypesOfStatsQuery: ``,
+    linkTypesStatisticsQuery: ``,
     filterRefElementLinkPattern: '',
     filterTypePattern: ``,
     filterAdditionalRestriction: ``,
@@ -241,7 +241,7 @@ const WikidataSettingsOverride: Partial<SparqlDataProviderSettings> = {
             FILTER regex(STR(?link), "direct")
         }
     `,
-    linkTypesOfStatsQuery: `
+    linkTypesStatisticsQuery: `
         SELECT ?link ?outCount ?inCount
         WHERE {
             { 
@@ -334,7 +334,7 @@ export const OWLRDFSSettingsOverride: Partial<SparqlDataProviderSettings> = {
             { ?inObject ?link \${elementIri} }
         }
     `,
-    linkTypesOfStatsQuery: `
+    linkTypesStatisticsQuery: `
         SELECT ?link ?outCount ?inCount
         WHERE {
             { 

--- a/src/ontodia/viewUtils/connectionsMenu.tsx
+++ b/src/ontodia/viewUtils/connectionsMenu.tsx
@@ -193,7 +193,7 @@ export class ConnectionsMenu extends React.Component<ConnectionsMenuProps, void>
                 y: startY + (yi) * GRID_STEP,
             });
         });
-        const { link } = this.linkDataChunk;
+        const link = this.linkDataChunk ? this.linkDataChunk.link : undefined;
         const hasChosenLinkType = this.linkDataChunk && link !== ALL_RELATED_ELEMENTS_LINK;
         if (hasChosenLinkType && !link.visible) {
             // prevent loading here because of .requestLinksOfType() call
@@ -207,12 +207,13 @@ export class ConnectionsMenu extends React.Component<ConnectionsMenuProps, void>
     }
 
     private onExpandLink = (linkDataChunk: LinkDataChunk) => {
-        if (
-            !this.linkDataChunk ||
-            this.linkDataChunk.link !== linkDataChunk.link ||
-            !this.objects ||
-            this.linkDataChunk.direction !== linkDataChunk.direction
-        ) {
+        const alreadyLoaded = (
+            this.objects &&
+            this.linkDataChunk &&
+            this.linkDataChunk.link === linkDataChunk.link &&
+            this.linkDataChunk.direction === linkDataChunk.direction
+        );
+        if (!alreadyLoaded) {
             this.loadObjects(linkDataChunk);
         }
         this.updateAll();
@@ -802,10 +803,13 @@ class ObjectsPanel extends React.Component<ObjectsPanelProps, {
             `\u00A0(${wrongNodesString})` : `\u00A0(${wrongNodesString})`);
         const wrongNodesTitle = wrongNodes === 0 ? '' : (wrongNodes > 0 ? 'Unavailable nodes' : 'Extra nodes');
 
-        return <label className='ontodia-label ontodia-connections-menu_objects-panel_bottom-panel__count-label'>
+        return <div className='ontodia-label ontodia-connections-menu_objects-panel_bottom-panel__count-label'>
             <span>{countString}</span>
-            <span className='extra' title={wrongNodesTitle}>{wrongNodesCount}</span>
-        </label>;
+            <span className='ontodia-connections-menu_objects-panel_bottom-panel__extra-elements'
+                  title={wrongNodesTitle}>
+                {wrongNodesCount}
+            </span>
+        </div>;
     }
 
     render() {
@@ -830,7 +834,7 @@ class ObjectsPanel extends React.Component<ObjectsPanelProps, {
                     {objectViews}
                     {this.props.data.linkDataChunk.expectedCount > MAX_LINK_COUNT ?
                         <div
-                            className='element-in-popup-menu'
+                            className='element-in-popup-menu move-to-filter-line'
                             onClick={() => this.props.onMoveToFilter(this.props.data.linkDataChunk)}
                         >
                             The list was truncated, for more data click here to use the filter panel.

--- a/src/ontodia/viewUtils/connectionsMenu.tsx
+++ b/src/ontodia/viewUtils/connectionsMenu.tsx
@@ -8,7 +8,6 @@ import { DiagramView } from '../diagram/view';
 import { chooseLocalizedText } from '../diagram/model';
 
 import { Dictionary, LocalizedString, ElementModel } from '../data/model';
-
 import { EventObserver } from './events';
 
 type Label = { values: LocalizedString[] };
@@ -20,6 +19,7 @@ export interface ReactElementModel {
 }
 
 const MENU_OFFSET = 40;
+const MAX_LINK_COUNT = 100;
 const ALL_RELATED_ELEMENTS_LINK: FatLinkType = new FatLinkType({
     id: 'allRelatedElements',
     label: [{lang: '', text: 'All'}],
@@ -40,6 +40,18 @@ export interface PropertyScore {
     score: number;
 }
 
+export interface LinkDataChunk {
+    link: FatLinkType;
+    direction?: 'in' | 'out';
+    expectedCount: number;
+    offset?: number;
+}
+
+export interface ObjectsData {
+    linkDataChunk: LinkDataChunk;
+    objects: ReactElementModel[];
+}
+
 export interface ConnectionsMenuProps extends PaperWidgetProps {
     view: DiagramView;
     target: Element;
@@ -56,9 +68,8 @@ export class ConnectionsMenu extends React.Component<ConnectionsMenuProps, void>
     private links: FatLinkType[];
     private countMap: { [linkTypeId: string]: ConnectionCount };
 
-    private selectedLink: FatLinkType;
+    private linkDataChunk: LinkDataChunk;
     private objects: ReactElementModel[];
-    private direction: 'in' | 'out';
 
     private updateAll = () => this.forceUpdate();
 
@@ -118,46 +129,30 @@ export class ConnectionsMenu extends React.Component<ConnectionsMenuProps, void>
                 this.loadingState = 'error';
                 this.updateAll();
             });
+        this.updateAll();
     }
 
-    private loadObjects(link: FatLinkType, direction?: 'in' | 'out') {
+    private loadObjects(linkDataChunk: LinkDataChunk) {
         const {view, target} = this.props;
+        const {link, direction, expectedCount } = linkDataChunk;
+        const offset = (linkDataChunk.offset || 0);
 
         this.loadingState = 'loading';
-        this.selectedLink = link;
+        this.linkDataChunk = linkDataChunk;
         this.objects = [];
-        this.direction = direction;
 
-        const {inCount, outCount} = this.countMap[link.id];
-        const count =
-            direction === 'in' ? inCount :
-            direction === 'out' ? outCount :
-            (inCount + outCount);
-
-        const requestsCount = Math.ceil(count / 100);
-
-        const requests: Promise<Dictionary<ElementModel>>[] = [];
-        for (let i = 0; i < requestsCount; i++) {
-            requests.push(
-                view.model.dataProvider.linkElements({
-                    elementId: target.id,
-                    linkId: (link === ALL_RELATED_ELEMENTS_LINK ? undefined : this.selectedLink.id),
-                    limit: 100,
-                    offset: i * 100,
-                    direction,
-                })
-            );
-        }
-
-        Promise.all(requests).then(results => {
+        view.model.dataProvider.linkElements({
+            elementId: target.id,
+            linkId: (link === ALL_RELATED_ELEMENTS_LINK ? undefined : link.id),
+            limit: offset + MAX_LINK_COUNT,
+            offset: offset,
+            direction,
+        }).then(elements => {
             this.loadingState = 'completed';
-            this.objects = [];
-            results.forEach(elements => {
-                Object.keys(elements).forEach(key => this.objects.push({
-                    model: elements[key],
-                    presentOnDiagram: Boolean(view.model.getElement(key)),
-                }));
-            });
+            this.objects = Object.keys(elements).map(key => ({
+                model: elements[key],
+                presentOnDiagram: Boolean(view.model.getElement(key)),
+            }));
             this.updateAll();
         }).catch(err => {
             console.error(err);
@@ -198,11 +193,11 @@ export class ConnectionsMenu extends React.Component<ConnectionsMenuProps, void>
                 y: startY + (yi) * GRID_STEP,
             });
         });
-
-        const hasChosenLinkType = this.selectedLink && this.selectedLink !== ALL_RELATED_ELEMENTS_LINK;
-        if (hasChosenLinkType && !this.selectedLink.visible) {
+        const { link } = this.linkDataChunk;
+        const hasChosenLinkType = this.linkDataChunk && link !== ALL_RELATED_ELEMENTS_LINK;
+        if (hasChosenLinkType && !link.visible) {
             // prevent loading here because of .requestLinksOfType() call
-            this.selectedLink.setVisibility({visible: true, showLabel: true, preventLoading: true});
+            link.setVisibility({visible: true, showLabel: true, preventLoading: true});
         }
 
         view.model.requestElementData(addedElements);
@@ -211,15 +206,22 @@ export class ConnectionsMenu extends React.Component<ConnectionsMenuProps, void>
         onClose();
     }
 
-    private onExpandLink = (link: FatLinkType, direction?: 'in' | 'out') => {
-        if (this.selectedLink !== link || !this.objects || this.direction !== direction) {
-            this.loadObjects(link, direction);
+    private onExpandLink = (linkDataChunk: LinkDataChunk) => {
+        if (
+            !this.linkDataChunk ||
+            this.linkDataChunk.link !== linkDataChunk.link ||
+            !this.objects ||
+            this.linkDataChunk.direction !== linkDataChunk.direction
+        ) {
+            this.loadObjects(linkDataChunk);
         }
         this.updateAll();
     }
 
-    private onMoveToFilter = (link: FatLinkType, direction?: 'in' | 'out') => {
+    private onMoveToFilter = (linkDataChunk: LinkDataChunk) => {
         const {view, target} = this.props;
+        const {link, direction} = linkDataChunk;
+
         if (link === ALL_RELATED_ELEMENTS_LINK) {
             target.addToFilter();
         } else {
@@ -234,14 +236,11 @@ export class ConnectionsMenu extends React.Component<ConnectionsMenuProps, void>
             countMap: this.countMap || {},
         };
 
-        let objectsData: {
-            selectedLink: FatLinkType;
-            objects: ReactElementModel[];
-        } = null;
+        let objectsData: ObjectsData = null;
 
-        if (this.selectedLink && this.objects) {
+        if (this.linkDataChunk && this.objects) {
             objectsData = {
-                selectedLink: this.selectedLink,
+                linkDataChunk: this.linkDataChunk,
                 objects: this.objects,
             };
         }
@@ -273,17 +272,14 @@ interface ConnectionsMenuMarkupProps {
         countMap: { [linkTypeId: string]: ConnectionCount };
     };
 
-    objectsData?: {
-        selectedLink?: FatLinkType;
-        objects: ReactElementModel[];
-    };
+    objectsData?: ObjectsData;
 
     lang: string;
     state: 'loading' | 'error' | 'completed';
 
-    onExpandLink?: (link: FatLinkType, direction?: 'in' | 'out') => void;
+    onExpandLink?: (linkDataChunk: LinkDataChunk) => void;
     onPressAddSelected?: (selectedObjects: ReactElementModel[]) => void;
-    onMoveToFilter?: (link: FatLinkType, direction?: 'in' | 'out') => void;
+    onMoveToFilter?: (linkDataChunk: LinkDataChunk) => void;
 
     propertySuggestionCall?: PropertySuggestionHandler;
 }
@@ -318,9 +314,9 @@ class ConnectionsMenuMarkup extends React.Component<ConnectionsMenuMarkupProps, 
         return 'Error';
     };
 
-    private onExpandLink = (link: FatLinkType, direction?: 'in' | 'out') => {
+    private onExpandLink = (linkDataChunk: LinkDataChunk) => {
         this.setState({ filterKey: '',  panel: 'objects' });
-        this.props.onExpandLink(link, direction);
+        this.props.onExpandLink(linkDataChunk);
     };
 
     private onCollapseLink = () => {
@@ -333,9 +329,9 @@ class ConnectionsMenuMarkup extends React.Component<ConnectionsMenuMarkupProps, 
                 <a className='ontodia-link' onClick={this.onCollapseLink}>Connections</a>{'\u00A0' + '/' + '\u00A0'}
                 {
                     chooseLocalizedText(
-                        this.props.objectsData.selectedLink.label,
+                        this.props.objectsData.linkDataChunk.link.label,
                         this.props.lang
-                    ).text.toLowerCase()
+                    ).text.toLowerCase() + ` (${this.props.objectsData.linkDataChunk.direction})`
                 }
             </span>
             : ''
@@ -348,6 +344,7 @@ class ConnectionsMenuMarkup extends React.Component<ConnectionsMenuMarkupProps, 
         } else if (this.props.objectsData && this.state.panel === 'objects') {
             return <ObjectsPanel
                 data={this.props.objectsData}
+                onMoveToFilter={this.props.onMoveToFilter}
                 lang={this.props.lang}
                 filterKey={this.state.filterKey}
                 loading={this.props.state === 'loading'}
@@ -464,8 +461,8 @@ interface ConnectionsListProps {
     lang: string;
     filterKey: string;
 
-    onExpandLink?: (link: FatLinkType, direction?: 'in' | 'out') => void;
-    onMoveToFilter?: (link: FatLinkType, direction?: 'in' | 'out') => void;
+    onExpandLink?: (linkDataChunk: LinkDataChunk) => void;
+    onMoveToFilter?: (linkDataChunk: LinkDataChunk) => void;
 
     propertySuggestionCall?: PropertySuggestionHandler;
     sortMode: SortMode;
@@ -625,8 +622,8 @@ interface LinkInPopupMenuProps {
     direction?: 'in' | 'out';
     lang?: string;
     filterKey?: string;
-    onExpandLink?: (link: FatLinkType, direction?: 'in' | 'out') => void;
-    onMoveToFilter?: (link: FatLinkType, direction?: 'in' | 'out') => void;
+    onExpandLink?: (linkDataChunk: LinkDataChunk) => void;
+    onMoveToFilter?: (linkDataChunk: LinkDataChunk) => void;
     probability?: number;
 }
 
@@ -635,13 +632,21 @@ class LinkInPopupMenu extends React.Component<LinkInPopupMenuProps, {}> {
         super(props);
     }
 
-    private onExpandLink = (direction?: 'in' | 'out') => {
-        this.props.onExpandLink(this.props.link, direction);
+    private onExpandLink = (expectedCount: number, direction?: 'in' | 'out') => {
+        this.props.onExpandLink({
+            link: this.props.link,
+            direction,
+            expectedCount,
+        });
     }
 
     private onMoveToFilter = (evt: React.MouseEvent<any>) => {
         evt.stopPropagation();
-        this.props.onMoveToFilter(this.props.link, this.props.direction);
+        this.props.onMoveToFilter({
+            link: this.props.link,
+            direction: this.props.direction,
+            expectedCount: this.props.count,
+        });
     }
 
     render() {
@@ -660,7 +665,7 @@ class LinkInPopupMenu extends React.Component<LinkInPopupMenuProps, {}> {
         return (
             <li data-linkTypeId={this.props.link.id}
                 className='link-in-popup-menu' title={navigationTitle}
-                onClick={() => this.onExpandLink(this.props.direction)}>
+                onClick={() => this.onExpandLink(this.props.count, this.props.direction)}>
                 {this.props.direction === 'in' || this.props.direction === 'out' ?
                 <div className='link-in-popup-menu_direction'>
                     {this.props.direction === 'in' && <div className='link-in-popup-menu_direction__in-direction' />}
@@ -668,7 +673,9 @@ class LinkInPopupMenu extends React.Component<LinkInPopupMenuProps, {}> {
                 </div>
                 : null}
                 <div className='link-in-popup-menu__link-title'>{textLine}</div>
-                <span className='ontodia-badge link-in-popup-menu__count'>{this.props.count}</span>
+                <span className='ontodia-badge link-in-popup-menu__count'>
+                    {this.props.count <= MAX_LINK_COUNT ? this.props.count : '100+'}
+                </span>
                 <a className='filter-button' onClick={this.onMoveToFilter}
                     title='Set as filter in the Instances panel'><img/></a>
                 <div className='link-in-popup-menu__navigate-button' title={navigationTitle} />
@@ -678,14 +685,12 @@ class LinkInPopupMenu extends React.Component<LinkInPopupMenuProps, {}> {
 }
 
 interface ObjectsPanelProps {
-    data: {
-        selectedLink?: FatLinkType;
-        objects: ReactElementModel[]
-    };
+    data: ObjectsData;
     loading?: boolean;
     lang?: string;
     filterKey?: string;
     onPressAddSelected?: (selectedObjects: ReactElementModel[]) => void;
+    onMoveToFilter?: (linkDataChunk: LinkDataChunk) => void;
 }
 
 class ObjectsPanel extends React.Component<ObjectsPanelProps, {
@@ -786,12 +791,29 @@ class ObjectsPanel extends React.Component<ObjectsPanelProps, {
         );
     };
 
+    private counter = (activeObjCount: number) => {
+        const countString = `${activeObjCount}\u00A0of\u00A0${this.props.data.objects.length}`;
+
+        const wrongNodes =
+            Math.min(MAX_LINK_COUNT, this.props.data.linkDataChunk.expectedCount) - this.props.data.objects.length;
+        const wrongNodesString = Math.abs(wrongNodes) > MAX_LINK_COUNT ?
+            `${MAX_LINK_COUNT}+` : Math.abs(wrongNodes).toString();
+        const wrongNodesCount = wrongNodes === 0 ? '' : (wrongNodes < 0 ?
+            `\u00A0(${wrongNodesString})` : `\u00A0(${wrongNodesString})`);
+        const wrongNodesTitle = wrongNodes === 0 ? '' : (wrongNodes > 0 ? 'Unavailable nodes' : 'Extra nodes');
+
+        return <label className='ontodia-label ontodia-connections-menu_objects-panel_bottom-panel__count-label'>
+            <span>{countString}</span>
+            <span className='extra' title={wrongNodesTitle}>{wrongNodesCount}</span>
+        </label>;
+    }
+
     render() {
         this.updateCheckMap();
         const objects = this.getFilteredObjects();
         const objectViews = this.getObjects(objects);
         const activeObjCount = objects.filter(el => this.state.checkMap[el.model.id]  && !el.presentOnDiagram).length;
-        const countString = activeObjCount.toString() + '\u00A0of\u00A0' + this.props.data.objects.length;
+
         return <div className='ontodia-connections-menu_objects-panel'>
             <div className='ontodia-connections-menu_objects-panel__select-all' onClick={this.onSelectAll}>
                 <input className={this.state.selectAll === 'undefined' ? 'undefined' : ''}
@@ -801,15 +823,22 @@ class ObjectsPanel extends React.Component<ObjectsPanelProps, {
             </div>
             {(
                 this.props.loading ?
-                <label className='ontodia-label ontodia-connections-menu__loading-objects'>Loading...</label>
-                : <div className='ontodia-connections-menu_objects-panel_objects-list'>
+                <label className='ontodia-label ontodia-connections-menu__loading-objects'>Loading...</label> :
+                objectViews.length === 0 ?
+                <label className='ontodia-label ontodia-connections-menu__loading-objects'>No available nodes</label> :
+                <div className='ontodia-connections-menu_objects-panel_objects-list'>
                     {objectViews}
+                    {this.props.data.linkDataChunk.expectedCount > MAX_LINK_COUNT ?
+                        <div
+                            className='element-in-popup-menu'
+                            onClick={() => this.props.onMoveToFilter(this.props.data.linkDataChunk)}
+                        >
+                            The list was truncated, for more data click here to use the filter panel.
+                        </div> : ''}
                 </div>
             )}
             <div className='ontodia-connections-menu_objects-panel_bottom-panel'>
-                <label className='ontodia-label ontodia-connections-menu_objects-panel_bottom-panel__count-label'>
-                    <span>{countString}</span>
-                </label>
+                {this.counter(activeObjCount)}
                 <button className={
                         'ontodia-btn ontodia-btn-primary pull-right ' +
                         'ontodia-connections-menu_objects-panel_bottom-panel__add-button'

--- a/styles/diagram/_connectionsMenu.scss
+++ b/styles/diagram/_connectionsMenu.scss
@@ -144,7 +144,7 @@
   }
 }
 
-div.element-in-popup-menu {
+.element-in-popup-menu .move-to-filter-message {
   background-color: #d8e7f5;
   border: 1px solid #c4d6e6;
   color: gray;
@@ -301,7 +301,7 @@ div.element-in-popup-menu {
   max-width: 60%;
 }
 
-.ontodia-connections-menu_objects-panel_bottom-panel__count-label .extra {
+.ontodia-connections-menu_objects-panel_bottom-panel__extra-elements {
   color: gray;
   cursor: help;
 }

--- a/styles/diagram/_connectionsMenu.scss
+++ b/styles/diagram/_connectionsMenu.scss
@@ -136,9 +136,22 @@
   padding: 5px 10px;
   margin: 5px 10px;
   border-radius: 5px;
+  user-select: none;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #e6e6e6;
+  }
 }
-.element-in-popup-menu:hover {
-  background-color: #e6e6e6;
+
+div.element-in-popup-menu {
+  background-color: #d8e7f5;
+  border: 1px solid #c4d6e6;
+  color: gray;
+  
+  &:hover {
+    background-color: #cdddec;
+  }
 }
 
 .element-in-popup-menu.unchecked {
@@ -274,6 +287,8 @@
 .ontodia-connections-menu_objects-panel_bottom-panel {
   height: 25px;
   white-space: nowrap;
+  display: flex;
+  justify-content: space-between;
 }
 
 .ontodia-connections-menu_objects-panel_bottom-panel__count-label {
@@ -284,6 +299,11 @@
   display: flex;
   align-items: center;
   max-width: 60%;
+}
+
+.ontodia-connections-menu_objects-panel_bottom-panel__count-label .extra {
+  color: gray;
+  cursor: help;
 }
 
 .ontodia-btn.ontodia-connections-menu_objects-panel_bottom-panel__add-button {


### PR DESCRIPTION
The limit is 100 items max.

Renamed settings field names and added comments
LinkTypesOfQuery was modified to be able to display data even if there is big amount of related links. The case when data is counted but not obtained was handled.