### PR TITLE
Fix printing, add font-family property to links label

### DIFF
--- a/src/ontodia/customization/props.ts
+++ b/src/ontodia/customization/props.ts
@@ -90,6 +90,7 @@ export interface LinkLabel {
             fill?: string;
             stroke?: string;
             'stroke-width'?: number;
+            'font-family'?: string;
             'font-size'?: string | number;
             'font-weight'?: 'normal' | 'bold' | 'lighter' | 'bolder' | number;
             text?: LocalizedString[];

--- a/src/ontodia/diagram/linkLayer.tsx
+++ b/src/ontodia/diagram/linkLayer.tsx
@@ -355,10 +355,11 @@ function getLabelTextAttributes(label: LinkLabelProperties): TextAttributes {
         fill = 'black',
         stroke = 'none',
         'stroke-width': strokeWidth = 0,
+        'font-family': fontFamily = '"Helvetica Neue", "Helvetica", "Arial", sans-serif',
         'font-size': fontSize = 'inherit',
         'font-weight': fontWeight = 'bold',
     } = label.attrs ? label.attrs.text : {};
-    return {fill, stroke, strokeWidth, fontSize, fontWeight};
+    return {fill, stroke, strokeWidth, fontFamily, fontSize, fontWeight};
 }
 
 function getLabelRectAttributes(label: LinkLabelProperties): RectAttributes {
@@ -383,6 +384,7 @@ interface TextAttributes {
     stroke?: string;
     strokeWidth?: number;
     fill?: string;
+    fontFamily?: string;
     fontSize?: string | number;
     fontWeight?: 'normal' | 'bold' | 'lighter' | 'bolder' | number;
 }

--- a/src/ontodia/workspace/workspace.ts
+++ b/src/ontodia/workspace/workspace.ts
@@ -316,6 +316,7 @@ export class Workspace extends Component<WorkspaceProps, State> {
         this.markup.paperArea.exportSVG().then(svg => {
             const printWindow = window.open('', undefined, 'width=1280,height=720');
             printWindow.document.write(svg);
+            printWindow.document.close();
             printWindow.print();
         });
     }


### PR DESCRIPTION
Close a stream to tell the browser to finish loading the page.
Add the 'font-family' property to a links label to properly display labels in a print window.