### PR TITLE
fixed error in sparql diagrams, unresolved prefix error

### DIFF
--- a/src/ontodia/data/sparql/sparqlDataProvider.ts
+++ b/src/ontodia/data/sparql/sparqlDataProvider.ts
@@ -696,7 +696,7 @@ export class SparqlDataProvider implements DataProvider {
             .filter(iri => !BlankNodes.isEncodedBlank(iri))
             .map(iri => `(${escapeIri(iri)})`).join(' ');
 
-        const queryTemplate = `SELECT ?inst ?class { VALUES(?inst) { \${ids} } \${filterTypePattern} }`;
+        const queryTemplate = this.settings.defaultPrefix +`SELECT ?inst ?class { VALUES(?inst) { \${ids} } \${filterTypePattern} }`;
         const query = resolveTemplate(queryTemplate, {ids, filterTypePattern});
         let response = await this.executeSparqlQuery<ElementTypeBinding>(query);
 


### PR DESCRIPTION
from sparql.ts the diagram was not rendering the links. 
the crash happens because there was an unresolved prefix error.
with this line the diagram work perfectly without errors.
Before fix. subclass relation not shown between Agent and Organization.
![image](https://user-images.githubusercontent.com/4159292/155008629-019fab00-6f80-440d-abe6-a0ebc1dd9ba4.png)

After fix
![image](https://user-images.githubusercontent.com/4159292/155008775-d819c24c-d58b-4574-8bcc-979947a914a3.png)
